### PR TITLE
Remove generic, internal or overly specific terms

### DIFF
--- a/app/index.md
+++ b/app/index.md
@@ -11,47 +11,9 @@ eleventyComputed:
 
 ## A
 
-### Accreditation
-
-All initial teacher training providers must be ‘accredited’ by the Secretary of State for Education. This process of ‘accreditation’ confirms they have permission to offer courses leading to Qualified Teacher Status (QTS). (NB: Ofsted is the body which checks the courses providers offer meet the standards set by the department.)
-
-The exception is the School Direct (SD) training route; SDs need a ‘ratifying accredited provider’. The ratifying accredited provider may be a School Centred Initial Teacher Training (SCITT) or a Higher Education Institute (HEI), and is responsible for maintaining the quality of the training provided.
-
-As accredited bodies, SCITTs can offer QTS courses but do not have the power to award a degree. To enable candidates who seek an academic award like a PGCE (Post Graduate Certificate in Education) they need to partner with an HEI.
-
-The relationship between accredited training providers and the institutions they ratify is complex. For example, we know that individual courses can be ratified by different accredited bodies (so a School Direct may work with both an HEI and more than one SCITT to ratify its courses).
-
-### Allocation
-
-Permission to run limited courses.
-
 ### Ancient languages
 
 Used to describe teaching the study of languages no longer in widespread spoken usage, such as Latin or Ancient Greek. Prefer using the specific languages studied where possible.
-
-## B
-
-### Becoming a teacher (BAT)
-
-An internal term used to describe all of the services related to the journey to become a teacher (sometimes referred to as a ‘service line’).
-
-### Bursaries AND Scholarships
-
-These are sums of money available to trainees on (fee-based) courses in certain subjects. They’re tax-free, and awarded by DfE, in some cases in partnership with professional bodies. The main difference between bursaries and scholarships is that the value of scholarships is a little higher, and you’ll generally need a 2:1 to qualify for one (you’ll only need a 2:2 to get a bursary). You also have to apply for a scholarship, whereas you’ll automatically receive a bursary once you start training (if you meet the criteria). You can only claim one of them - not both.
-
-## C
-
-### Course
-
-A training programme providers create for candidates to apply to.
-
-### Course Code
-
-A code used to identify courses (unique to a provider).
-
-### Cycle
-
-The period during which initial teacher training (ITT) applications are open, usually beginning in October and ending in September.
 
 ## D
 
@@ -119,17 +81,7 @@ A UK teaching qualification where applicants study and train outside of the UK, 
 
 Statutory guidance for schools and colleges on safeguarding children and safer recruitment. See [Keeping children safe in education](https://www.gov.uk/government/publications/keeping-children-safe-in-education--2).
 
-## L
-
-### Lead school
-
-Within initial teacher training (ITT), this refers to the main organisation in a School Direct partnership. It can be a maintained school, academy, head office, sixth form college, pupil referral unit, or free school. It partners with other schools and accredited bodies to deliver teacher training courses. It has overall responsibility for making sure that School Direct criteria are upheld, and for requesting training places from DfE. Places are allocated directly to the lead school. A ’good’ or ’outstanding’ Ofsted rating is a requirement for lead schools.
-
 ## M
-
-### Marketing name
-
-The commonly used name of an educational organisation. This may not be the legal name.
 
 ### Modern languages
 
@@ -141,12 +93,6 @@ This term is sometimes used to differentiate the teaching of languages in everyd
 ### National Association of School-Based Teacher Trainers (NASBTT)
 
 The [National Association of School-Based Teacher Trainers](https://www.nasbtt.org.uk) is a registered charity which represents the interests of schools-led teacher training provision in relation to the development and implementation of national policy developments. They are the largest representative body of SCITTs and School Directs.
-
-## O
-
-### Organisation
-
-A generic term used broadly to encompass the different types of entity involving in teacher training (schools, universities, School Directs, etc). Use a more specific term where appropriate.
 
 ## P
 
@@ -161,66 +107,19 @@ Very similar to the PGCE. Generally includes more credits towards a Master’s d
 ### Postgraduate initial teacher training (PGITT)
 
 Initial teacher training done after graduating with a degree.
-
-### Provider led
-
-A course that that is led by an HEI or a SCITT (the opposite of school led/based).
-
-## Q
-
-## R
-
-### Rollover
-
-Within initial teacher training, this refers to the copying over of courses from one recruitment cycle to the next. It starts in mid July and takes about a month in full. All courses are copied over; training providers can then eliminate any courses they don’t want to run, and make any other changes to ensure their course profiles are correct for the upcoming cycle.
+ to ensure their course profiles are correct for the upcoming cycle.
 
 ## S
-
-### Scholarships
-
-See [Bursaries](#bursaries-and-scholarships).
 
 ### School centred initial teacher training (SCITT)
 
 Within initial teacher training, School-centred initial teacher training (SCITT) is most commonly a school who have incorporated a separate legal entity (company) dedicated to delivering teacher training. SCITTs are accredited bodies.
 
-### School direct (SD)
-
-Within initial teacher training, these are single schools able to recruit trainees. They must partner with an accredited body.
-
-### SITS
-
-SITS:Vision, also known just as SITS, is a database application used for course and student management developed and maintained by the [Tribal Group](https://en.wikipedia.org/wiki/SITS:Vision). This is the most common student record system used by providers.
-
-### Student record system (SRS)
-
-Database application commonly used by further and higher education institutions to store, administer and manage all types of student information. Vendors of this software include Ellucian, Technology One, Tribal and Unit 4.
-
 ## T
-
-### Teacher Analysis Division (TAD)
-
-Part of DfE.
-
-### Teacher Qualifications Unit (TQU)
-
-Administers the Database of Qualified Teachers.
 
 ### Teacher Regulation Agency (TRA)
 
 An executive agency of the DfE who maintains the database of qualified teachers in England, issues the TRN, awards QTS to teachers who complete ITT and awards EYTS to teachers who complete EYITT.
-
-### Teacher supply model (TSM)
-
-Used to predict and manage the ITT market.
-
-### Teacher workforce model (TWM)
-
-A statistical model used to predict and set targets for the numbers of teachers needed in the workforce.
-
-### Teaching School Alliance
-
-Outstanding schools that work with others to provide high quality training to new and experienced staff. Cannot be lead schools or providers.
 
 ## U
 


### PR DESCRIPTION
These terms are all either generic, internal, or overly specific to the becoming a teacher services - and so are unlikely to be needed within a DfE style guide.